### PR TITLE
Timescrollview rollback

### DIFF
--- a/test-gui/devel/deploy_dev.sh
+++ b/test-gui/devel/deploy_dev.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+TARGET=gs://figurl/timeseries-views-1dev
+
+yarn build
+gsutil -m cp -R ./build/* $TARGET/

--- a/test-gui/package.json
+++ b/test-gui/package.json
@@ -2,6 +2,7 @@
   "name": "test-gui",
   "version": "0.1.0",
   "private": true,
+  "homepage": "./",
   "dependencies": {
     "@figurl/core-views": "^0.1",
     "@figurl/interface": "^0.1",

--- a/test-gui/src/package/component-time-scroll-view/TimeScrollView.tsx
+++ b/test-gui/src/package/component-time-scroll-view/TimeScrollView.tsx
@@ -61,6 +61,7 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
     const timeRange = useMemo(() => (
         [visibleTimeStartSeconds, visibleTimeEndSeconds] as [number, number]
     ), [visibleTimeStartSeconds, visibleTimeEndSeconds])
+    const panelWidthSeconds = (visibleTimeEndSeconds ?? 0) - (visibleTimeStartSeconds ?? 0)
 
     const definedMargins = useDefinedMargins(margins)
     const toolbarWidth = hideToolbar ? 0 : DefaultToolbarWidth
@@ -77,7 +78,7 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
     const timeControlActions = useActionToolbar(optionalActions ?? {})
     useEffect(() => suppressWheelScroll(divRef), [divRef])
     const handleWheel = useTimeScrollZoom(divRef, zoomRecordingSelection)
-    const {handleMouseDown, handleMouseUp, handleMouseLeave, handleMouseMove} = useTimeScrollEventHandlers(definedMargins.left, panelWidth, divRef)
+    const {handleMouseDown, handleMouseUp, handleMouseLeave, handleMouseMove} = useTimeScrollEventHandlers(definedMargins.left, panelWidth, panelWidthSeconds, divRef)
 
     // TODO: It'd be nice to show some sort of visual indication of how much zoom has been requested,
 

--- a/test-gui/src/package/component-time-scroll-view/TimeScrollViewInteractions/useTimeScrollPan.ts
+++ b/test-gui/src/package/component-time-scroll-view/TimeScrollViewInteractions/useTimeScrollPan.ts
@@ -1,20 +1,17 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { DebounceThrottleResolver, DebounceThrottleUpdater } from '../../util-rate-limiters';
-import { useDebouncer } from '../../util-rate-limiters/rateLimiters';
+import { useThrottler } from '../../util-rate-limiters/rateLimiters';
 
 export type PanState = {
-    anchorTime?: number,
-    anchorX?: number,
-    panning?: boolean
-    pannedTime?: number
+    anchorX?: number
     pannedX?: number
+    panning?: boolean
 }
 
 export type PanStateRef = React.MutableRefObject<PanState>
 
 export type PanUpdateProperties = {
     mouseX: number
-    time: number
 }
 
 type PanUpdateRefs = {
@@ -25,16 +22,16 @@ type PanUpdateRefs = {
 // Convenience alias for long fn signature
 type PanFn = (deltaT: number) => void
 type PanResolverProps = {
+    secondsPerPixel: number,
     panRecordingSelectionDeltaT: PanFn
 }
 
 
 const setNextPanUpdate: DebounceThrottleUpdater<PanUpdateProperties, PanUpdateRefs> = (refs, state) => {
     const { panStateRef } = refs
-    const { mouseX, time } = state
+    const { mouseX } = state
     if (!panStateRef.current.panning) return false
-    if (panStateRef.current.pannedTime === time && panStateRef.current.pannedX === mouseX) return false
-    panStateRef.current.pannedTime = time
+    if (panStateRef.current.pannedX === mouseX) return false
     panStateRef.current.pannedX = mouseX
 
     return true
@@ -43,27 +40,28 @@ const setNextPanUpdate: DebounceThrottleUpdater<PanUpdateProperties, PanUpdateRe
 
 const panResolver: DebounceThrottleResolver<PanUpdateRefs, PanResolverProps> = (refs, props) => {
     const {panStateRef} = refs
-    const {panRecordingSelectionDeltaT} = props
-    const deltaT = (panStateRef?.current?.anchorTime ?? 0) - (panStateRef?.current?.pannedTime ?? 0)
-    if (deltaT === 0) return
-    panRecordingSelectionDeltaT && panRecordingSelectionDeltaT(deltaT)
+    const {secondsPerPixel, panRecordingSelectionDeltaT} = props
+    if (panStateRef === undefined || panStateRef?.current === undefined) return
+    const deltaPx = (panStateRef.current.anchorX ?? 0) - (panStateRef.current.pannedX ?? 0)
+    if (deltaPx === 0) return
+
+    panStateRef.current.anchorX = panStateRef.current.pannedX
+    panRecordingSelectionDeltaT && panRecordingSelectionDeltaT(secondsPerPixel * deltaPx)
     // Don't reset panning state by default here--user may still be holding the mouse button
 }
 
 
-export const useDebouncedPan = (refs: PanUpdateRefs, panRecordingSelectionDeltaT: PanFn) => {
-    const resolverProps = useMemo(() => {return {panRecordingSelectionDeltaT}}, [panRecordingSelectionDeltaT])
-    const panHandler = useDebouncer(setNextPanUpdate, panResolver, refs, resolverProps, 50)
+export const useThrottledPan = (refs: PanUpdateRefs, secondsPerPixel: number, panRecordingSelectionDeltaT: PanFn) => {
+    const resolverProps = useMemo(() => {return {secondsPerPixel, panRecordingSelectionDeltaT}}, [secondsPerPixel, panRecordingSelectionDeltaT])
+    const panHandler = useThrottler(setNextPanUpdate, panResolver, refs, resolverProps, 50)
     return panHandler
 }
 
 
-const resetPanStateAnchor = (ref: PanStateRef, mouseX: number, time: number, cancelPendingPan: () => void) => {
-    ref.current.anchorTime = time
+const resetPanStateAnchor = (ref: PanStateRef, mouseX: number, cancelPendingPan: () => void) => {
     ref.current.anchorX = mouseX
     ref.current.panning = false
     ref.current.pannedX = undefined
-    ref.current.pannedTime = undefined
     cancelPendingPan()
 }
 
@@ -87,19 +85,19 @@ const isPanning = (ref: PanStateRef) => {
 }
 
 
-const useTimeScrollPan = (divRef: React.MutableRefObject<HTMLDivElement | null>, panRecordingSelectionDeltaT: PanFn) => {
+const useTimeScrollPan = (divRef: React.MutableRefObject<HTMLDivElement | null>, secondsPerPixel: number, panRecordingSelectionDeltaT: PanFn) => {
     const panStateRef = useRef<PanState>({})
     const refs = useMemo(() => {return {divRef, panStateRef}}, [divRef, panStateRef])
-    const { debouncer, cancelDebouncer } = useDebouncedPan(refs, panRecordingSelectionDeltaT)
-    const resetAnchor = useCallback((mouseX: number, time: number) => {
-        resetPanStateAnchor(panStateRef, mouseX, time, cancelDebouncer)
-    }, [panStateRef, cancelDebouncer])
+    const { throttler, cancelThrottled } = useThrottledPan(refs, secondsPerPixel, panRecordingSelectionDeltaT)
+    const resetAnchor = useCallback((mouseX: number) => {
+        resetPanStateAnchor(panStateRef, mouseX, cancelThrottled)
+    }, [panStateRef, cancelThrottled])
     const startPan = useCallback((mouseX: number) => startPanning(panStateRef, mouseX), [panStateRef])
-    const clearPan = useCallback(() => clearPanState(panStateRef, cancelDebouncer), [panStateRef, cancelDebouncer])
+    const clearPan = useCallback(() => clearPanState(panStateRef, cancelThrottled), [panStateRef, cancelThrottled])
     const panning = useCallback(() => isPanning(panStateRef), [panStateRef])
 
     return {
-        setPanUpdate: debouncer,
+        setPanUpdate: throttler,
         resetAnchor,
         startPan,
         clearPan,

--- a/test-gui/src/package/context-recording-selection/RecordingSelectionContext.ts
+++ b/test-gui/src/package/context-recording-selection/RecordingSelectionContext.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react'
+import React, { useCallback, useContext, useEffect } from 'react'
 
 export type RecordingSelection = {
     recordingStartTimeSeconds?: number
@@ -121,11 +121,11 @@ export const useTimeRange = (timestampOffset=0) => {
 
 export const useTimeFocus = () => {
     const {recordingSelection, recordingSelectionDispatch} = useRecordingSelection()
-    const timeForFraction = useMemo(() => ((fraction: number) => {
+    const timeForFraction = useCallback((fraction: number) => {
         const window = (recordingSelection.visibleTimeEndSeconds || 0) - (recordingSelection.visibleTimeStartSeconds || 0)
         const time = window * fraction
         return time + (recordingSelection.visibleTimeStartSeconds || 0)
-    }), [recordingSelection.visibleTimeStartSeconds, recordingSelection.visibleTimeEndSeconds])
+    }, [recordingSelection.visibleTimeStartSeconds, recordingSelection.visibleTimeEndSeconds])
     const setTimeFocus = useCallback((time: number, o: {autoScrollVisibleTimeRange?: boolean}={}) => {
         recordingSelectionDispatch({
             type: 'setFocusTime',
@@ -269,7 +269,7 @@ const panTimeHelper = (state: RecordingSelection, panDisplacementSeconds: number
         return state
     }
     const windowLength = state.visibleTimeEndSeconds - state.visibleTimeStartSeconds
-    let newStart = state.visibleTimeStartSeconds    
+    let newStart = state.visibleTimeStartSeconds
     let newEnd = state.visibleTimeEndSeconds
     if (panDisplacementSeconds > 0) {
         // panning forward. Just need to check that we don't run over the end of the recording.


### PR DESCRIPTION
See https://www.figurl.org/f?v=gs://figurl/timeseries-views-1dev&d=sha1://dfb82b18910ba97aa30ef299cc5fd2cd0f9dbe08&label=Timeseries%20graph%20example&s={} for working example.

This PR introduces changes to the TimeScrollView base component to remove dependence on specific times. The immediate impetus is to fix the rollback issue described in Issue #2 but hopefully this will also eliminate some unnecessary re-instantiation of a base function that would drive a lot more rerenders.

Specifically, the `ClickReader` function in `TimeScrollEventHandlers.useClickReader()` no longer attempts to return the specific time corresponding to a particular interacted pixel. This reduces rerenders because the click reader had to close over a function that was aware of the start time of the visible window, which changes on panning; instead we only worry about the actual width of the window (which changes less often). (Do note that I have tested and changing the zoom level during an ongoing drag does also work.)

It might be a good idea to impose some rounding on the pixel-to-seconds proportion, to avoid rerenders due to rounding changes as the visible window changes, but I haven't gone there for this PR.

The only other trick is that after every (throttled) drag resolution occurs, we need to update the anchor pixel to the value of the current target pixel. If this is not done, then dragging keeps moving the wrong direction.

As an example, consider a window with 1 pixel per 10 seconds. The user drags from pixel 150 to pixel 250 and then to pixel 200. The first drag would move the window (100 pixels * 10 seconds/pixel) = 1000 seconds to the left. Once this window is complete, the user would expect that dragging back to pixel 200 should move the window in the opposite direction, 500 seconds to the right; however if we don't update the anchor. we would compute the second drag as moving (200 - 150 = 50 pixels) to the *left*.

Instead, after each render, we update the drag anchor to the original target. This actually aligns perfectly with the intuition of a drag--what the user wants is to take whatever time point is under the anchor and move it to the target. Once that's resolved, we expect the anchor time should actually be under that target pixel, so it makes sense to update the anchor to that new value.

The other changes are minor--adding a dev deploy script and updating a context method to a `useCallback` rather than a `useMemo` hook that happened to return a function. (This is more idiomatic but shouldn't have any runtime effect.)